### PR TITLE
Add SonarQube Server analysis to CI pipeline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,7 +59,6 @@ jobs:
       run: mvn --errors --show-version --batch-mode --no-transfer-progress -Ddoclint=all
     - name: SonarQube Analysis
       if: matrix.os == 'ubuntu-latest' && matrix.java == '17'
-      run: mvn sonar:sonar -Dsonar.projectKey=commons-lang -DskipTests
+      run: mvn sonar:sonar -Dsonar.projectKey=commons-lang -Dsonar.host.url=${{ vars.SONAR_HOST_URL }} -DskipTests
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,3 +57,9 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Build with Maven
       run: mvn --errors --show-version --batch-mode --no-transfer-progress -Ddoclint=all
+    - name: SonarQube Analysis
+      if: matrix.os == 'ubuntu-latest' && matrix.java == '17'
+      run: mvn sonar:sonar -Dsonar.projectKey=commons-lang -DskipTests
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}


### PR DESCRIPTION
## Add SonarQube Server Analysis

This PR integrates SonarQube Server static analysis into the CI pipeline, enabling continuous code quality and security inspection on every push.

### What was detected

| Property | Value |
|---|---|
| CI System | GitHub Actions |
| CI Configuration File | `.github/workflows/maven.yml` |
| SonarQube Scanner | Maven (`sonar-maven-plugin`) |
| SonarQube Project Key | `commons-lang` |

### Changes made

Added SonarQube Server analysis step to the GitHub Actions Maven workflow. The SonarQube analysis runs only on ubuntu-latest with Java 17 to avoid redundant analysis across the matrix. The step executes after the build and uses SONAR_TOKEN and SONAR_HOST_URL from GitHub secrets/variables. The -DskipTests flag is used since tests have already been run in the build step.

### Required secrets

Before merging, ensure the following secrets are configured in your repository settings:

| Secret | Description |
|---|---|
| `SONAR_TOKEN` | Authentication token for SonarQube Server |
| `SONAR_HOST_URL` | URL of your SonarQube Server instance |

> Generated automatically by sonar-ci-autoconfig